### PR TITLE
Add new status codes and total execution time metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ By default, per-worker metrics are disabled to reduce metric cardinality. To ena
 | `rspecq_build_flaky_failures` | Gauge | `build_id` | Number of flaky failures (examples that failed inconsistently) |
 | `rspecq_build_queue_status` | Gauge | `build_id`, `status` | Build queue status (1 = active for that status, 0 = inactive). Status values: `initializing`, `ready` |
 | `rspecq_build_fail_fast` | Gauge | `build_id` | Fail-fast threshold (0 = disabled) |
+| `rspecq_build_total_execution_time_seconds` | Gauge | `build_id` | Total execution time for the build in seconds (sum of all worker execution times) |
 
 ### Worker Metrics
 
@@ -212,6 +213,12 @@ rspecq_build_example_failures > 0
 time() - rspecq_build_worker_heartbeat_timestamp > 60
 ```
 
+### Total Worker Execution Time
+```promql
+# Total execution time across all workers for a build
+rspecq_build_total_execution_time_seconds
+```
+
 ## Grafana Dashboard
 
 A sample Grafana dashboard is available in `grafana/dashboard.json` (to be created). Import it to get started quickly.
@@ -252,6 +259,7 @@ RSpecQ stores data in Redis with the following key patterns:
 - `<build_id>:queue:elected_master_at` - STRING with Unix timestamp when master worker was elected
 - `<build_id>:queue:ready_at` - STRING with Unix timestamp when queue became ready
 - `<build_id>:queue:finished_at` - STRING with Unix timestamp when build finished
+- `<build_id>:build_execution_time_ms` - STRING with total execution time in milliseconds (sum of all worker execution times)
 
 **Global Data:**
 - `timings` - ZSET of global timing data for test scheduling

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ By default, per-worker metrics are disabled to reduce metric cardinality. To ena
 | `rspecq_build_non_example_errors` | Gauge | `build_id` | Number of non-example errors (e.g., syntax errors) |
 | `rspecq_build_requeues` | Gauge | `build_id` | Number of jobs that were requeued |
 | `rspecq_build_flaky_failures` | Gauge | `build_id` | Number of flaky failures (examples that failed inconsistently) |
-| `rspecq_build_queue_status` | Gauge | `build_id`, `status` | Build queue status (1 = active for that status, 0 = inactive). Status values: `initializing`, `ready` |
+| `rspecq_build_queue_status` | Gauge | `build_id`, `status` | Build queue status (1 = active for that status, 0 = inactive). Status values: `initializing`, `ready`, `success`, `failure` |
 | `rspecq_build_fail_fast` | Gauge | `build_id` | Fail-fast threshold (0 = disabled) |
 | `rspecq_build_total_execution_time_seconds` | Gauge | `build_id` | Total execution time for the build in seconds (sum of all worker execution times) |
 
@@ -213,6 +213,15 @@ rspecq_build_example_failures > 0
 time() - rspecq_build_worker_heartbeat_timestamp > 60
 ```
 
+### Successful vs Failed Builds
+```promql
+# Count of successful builds
+count(rspecq_build_queue_status{status="success"} == 1)
+
+# Count of failed builds
+count(rspecq_build_queue_status{status="failure"} == 1)
+```
+
 ### Total Worker Execution Time
 ```promql
 # Total execution time across all workers for a build
@@ -241,7 +250,7 @@ RSpecQ stores data in Redis with the following key patterns:
 - `<build_id>:queue:running` - HASH of jobs currently being executed
 - `<build_id>:queue:processed` - SET of completed jobs
 - `<build_id>:queue:lost` - ZSET of jobs lost due to worker failures
-- `<build_id>:queue:status` - STRING indicating queue status (`initializing` or `ready`)
+- `<build_id>:queue:status` - STRING indicating queue status (`initializing`, `ready`, `success`, `failure`)
 - `<build_id>:queue:config` - HASH containing configuration (e.g., `fail_fast` threshold)
 
 **Example Results:**

--- a/exporter.go
+++ b/exporter.go
@@ -32,18 +32,19 @@ type RSpecQExporter struct {
 	labelNames              []string
 
 	// Build-level metrics
-	buildUnprocessed      *prometheus.GaugeVec
-	buildRunning          *prometheus.GaugeVec
-	buildProcessed        *prometheus.GaugeVec
-	buildLost             *prometheus.GaugeVec
-	buildExamples         *prometheus.GaugeVec
-	buildExampleFailures  *prometheus.GaugeVec
-	buildNonExampleErrors *prometheus.GaugeVec
-	buildRequeues         *prometheus.GaugeVec
-	buildFlakyFailures    *prometheus.GaugeVec
-	buildStatus           *prometheus.GaugeVec
-	buildFailFast         *prometheus.GaugeVec
-	buildWithdrawnWorkers *prometheus.GaugeVec
+	buildUnprocessed        *prometheus.GaugeVec
+	buildRunning            *prometheus.GaugeVec
+	buildProcessed          *prometheus.GaugeVec
+	buildLost               *prometheus.GaugeVec
+	buildExamples           *prometheus.GaugeVec
+	buildExampleFailures    *prometheus.GaugeVec
+	buildNonExampleErrors   *prometheus.GaugeVec
+	buildRequeues           *prometheus.GaugeVec
+	buildFlakyFailures      *prometheus.GaugeVec
+	buildStatus             *prometheus.GaugeVec
+	buildFailFast           *prometheus.GaugeVec
+	buildWithdrawnWorkers   *prometheus.GaugeVec
+	buildTotalExecutionTime *prometheus.GaugeVec
 
 	// Worker-level metrics
 	workerHeartbeats *prometheus.GaugeVec
@@ -205,6 +206,14 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		},
 		exporter.labelNames,
 	)
+	exporter.buildTotalExecutionTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "build_total_execution_time_seconds",
+			Help:      "Total execution time for the build in seconds (sum of all worker execution times)",
+		},
+		exporter.labelNames,
+	)
 	exporter.buildWorkers = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -328,6 +337,7 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		exporter.buildReadyAt,
 		exporter.buildFinishedAt,
 		exporter.buildDuration,
+		exporter.buildTotalExecutionTime,
 	}
 
 	// Per-worker metrics (conditionally included)
@@ -367,6 +377,7 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		exporter.buildReadyAt,
 		exporter.buildFinishedAt,
 		exporter.buildDuration,
+		exporter.buildTotalExecutionTime,
 	}
 
 	// Add per-worker metrics to resetable list if enabled
@@ -586,6 +597,7 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	withdrawnKey := buildID + ":workers_withdrawn"
 	electedMasterKey := buildID + ":queue:elected_master_at"
 	readyKey := buildID + ":queue:ready_at"
+	executionTimeKey := buildID + ":build_execution_time_ms"
 
 	// Execute all commands atomically using pipeline with MULTI/EXEC
 	pipe := b.rdb.TxPipeline()
@@ -617,6 +629,7 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	electedMasterCmd := pipe.Get(ctx, electedMasterKey)
 	readyAtCmd := pipe.Get(ctx, readyKey)
 	finishedAtCmd := pipe.Get(ctx, finishedKey)
+	executionTimeCmd := pipe.Get(ctx, executionTimeKey)
 
 	// Execute the transaction
 	_, err := pipe.Exec(ctx)
@@ -727,6 +740,13 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	if ra, err := readyAtCmd.Int64(); err == nil {
 		readyAt = ra
 		e.buildReadyAt.With(labels).Set(float64(readyAt))
+	}
+
+	// Process results - Total execution time
+	if executionTimeMs, err := executionTimeCmd.Int64(); err == nil {
+		// Convert milliseconds to seconds
+		executionTimeSecs := float64(executionTimeMs) / 1000.0
+		e.buildTotalExecutionTime.With(labels).Set(executionTimeSecs)
 	}
 
 	// Check if build is running (no finished_at timestamp)

--- a/exporter.go
+++ b/exporter.go
@@ -186,7 +186,7 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "build_queue_status",
-			Help:      "Build queue status (0=initializing, 1=ready)",
+			Help:      "Build queue status (0=inactive, 1=active for each status: initializing, ready, success, failure)",
 		},
 		append(exporter.labelNames, "status"),
 	)
@@ -681,22 +681,22 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	// Process results - Status metrics
 	status, _ := statusCmd.Result()
 
-	// Set status gauges - only two statuses exist: initializing and ready
+	// Set all status gauges to 0 initially
 	statusLabels := make(prometheus.Labels)
 	for k, v := range labels {
 		statusLabels[k] = v
 	}
-	statusLabels["status"] = "initializing"
-	e.buildStatus.With(statusLabels).Set(0)
-	statusLabels["status"] = "ready"
-	e.buildStatus.With(statusLabels).Set(0)
 
+	// Reset all possible statuses to 0
+	for _, s := range []string{"initializing", "ready", "success", "failure"} {
+		statusLabels["status"] = s
+		e.buildStatus.With(statusLabels).Set(0)
+	}
+
+	// Set the current status to 1
 	switch status {
-	case "initializing":
-		statusLabels["status"] = "initializing"
-		e.buildStatus.With(statusLabels).Set(1)
-	case "ready":
-		statusLabels["status"] = "ready"
+	case "initializing", "ready", "success", "failure":
+		statusLabels["status"] = status
 		e.buildStatus.With(statusLabels).Set(1)
 	}
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -395,6 +395,9 @@ func TestE2E_HappyPath_AllMetrics(t *testing.T) {
 	rdb.Set(ctx, buildID+":queue:ready_at", baseTime+10, 0)
 	// Note: NOT setting :queue:finished_at so build stays in "ready" status
 
+	// NEW: Total execution time in milliseconds (sum of all worker execution times)
+	rdb.Set(ctx, buildID+":build_execution_time_ms", "125000", 0) // 125 seconds total
+
 	// Global metrics - note: keys are "timings" and "build_times" (not rspecq:timings)
 	rdb.ZAdd(ctx, "timings",
 		&redis.Z{Score: 1.5, Member: "spec1.rb"},
@@ -503,6 +506,11 @@ func TestE2E_HappyPath_AllMetrics(t *testing.T) {
 		// Withdrawn workers count (build-level metric)
 		{`rspecq_build_withdrawn_workers{build_id="e2e-test-build"}`, 2, func() float64 {
 			return testutil.ToFloat64(exporter.buildWithdrawnWorkers.WithLabelValues(buildID))
+		}},
+
+		// NEW: Total execution time metric (in seconds)
+		{`rspecq_build_total_execution_time_seconds{build_id="e2e-test-build"}`, 125.0, func() float64 {
+			return testutil.ToFloat64(exporter.buildTotalExecutionTime.WithLabelValues(buildID))
 		}},
 
 		// Global metrics

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -582,14 +582,100 @@ func TestE2E_HappyPath_AllMetrics(t *testing.T) {
 	}
 
 	// Ensure initializing status is 0 (only "ready" should be 1)
-	// There are only two statuses: initializing and ready
-	initializingMetric := `rspecq_build_queue_status{build_id="e2e-test-build",status="initializing"} 0`
-	if !strings.Contains(prometheusOutput, initializingMetric) {
-		t.Error("Expected initializing status to be 0")
+	// Now supports 4 statuses: initializing, ready, success, failure
+	statusTests := []struct {
+		status   string
+		expected float64
+	}{
+		{"initializing", 0},
+		{"ready", 1}, // Current build is in "ready" status
+		{"success", 0},
+		{"failure", 0},
+	}
+
+	for _, st := range statusTests {
+		statusMetric := fmt.Sprintf(`rspecq_build_queue_status{build_id="e2e-test-build",status="%s"} %v`, st.status, st.expected)
+		if !strings.Contains(prometheusOutput, statusMetric) {
+			t.Errorf("Expected status metric not found: %s", statusMetric)
+		}
 	}
 
 	t.Logf("✓ All metrics validated successfully!")
 	t.Logf("✓ Total metric families: %d", len(metricFamilies))
+
+	// Additional test: Verify a finished build with success/failure status
+	t.Run("FinishedBuildWithSuccessStatus", func(t *testing.T) {
+		successBuildID := "success-build-123"
+		finishedTime := baseTime + 120
+
+		// Set up a successful build
+		rdb.Set(ctx, successBuildID+":queue:status", "success", 0)
+		rdb.Set(ctx, successBuildID+":queue:ready_at", baseTime, 0)
+		rdb.Set(ctx, successBuildID+":queue:finished_at", finishedTime, 0)
+		rdb.Set(ctx, successBuildID+":build_execution_time_ms", "85000", 0) // 85 seconds
+		rdb.Set(ctx, successBuildID+":example_count", "200", 0)
+
+		exporter.scrape(ctx)
+
+		// Verify success status
+		successStatus := testutil.ToFloat64(exporter.buildStatus.WithLabelValues(successBuildID, "success"))
+		if successStatus != 1.0 {
+			t.Errorf("Expected success status to be 1, got %f", successStatus)
+		}
+
+		// Verify other statuses are 0
+		for _, status := range []string{"initializing", "ready", "failure"} {
+			val := testutil.ToFloat64(exporter.buildStatus.WithLabelValues(successBuildID, status))
+			if val != 0.0 {
+				t.Errorf("Expected %s status to be 0, got %f", status, val)
+			}
+		}
+
+		// Verify execution time
+		executionTime := testutil.ToFloat64(exporter.buildTotalExecutionTime.WithLabelValues(successBuildID))
+		if executionTime != 85.0 {
+			t.Errorf("Expected execution time 85.0 seconds, got %f", executionTime)
+		}
+
+		t.Logf("✓ Success build status and execution time validated")
+	})
+
+	t.Run("FinishedBuildWithFailureStatus", func(t *testing.T) {
+		failureBuildID := "failure-build-456"
+		finishedTime := baseTime + 90
+
+		// Set up a failed build
+		rdb.Set(ctx, failureBuildID+":queue:status", "failure", 0)
+		rdb.Set(ctx, failureBuildID+":queue:ready_at", baseTime, 0)
+		rdb.Set(ctx, failureBuildID+":queue:finished_at", finishedTime, 0)
+		rdb.Set(ctx, failureBuildID+":build_execution_time_ms", "60000", 0) // 60 seconds
+		rdb.Set(ctx, failureBuildID+":example_count", "100", 0)
+		rdb.HSet(ctx, failureBuildID+":example_failures", "failing_spec.rb", "assertion failed")
+
+		exporter.scrape(ctx)
+
+		// Verify failure status
+		failureStatus := testutil.ToFloat64(exporter.buildStatus.WithLabelValues(failureBuildID, "failure"))
+		if failureStatus != 1.0 {
+			t.Errorf("Expected failure status to be 1, got %f", failureStatus)
+		}
+
+		// Verify other statuses are 0
+		for _, status := range []string{"initializing", "ready", "success"} {
+			val := testutil.ToFloat64(exporter.buildStatus.WithLabelValues(failureBuildID, status))
+			if val != 0.0 {
+				t.Errorf("Expected %s status to be 0, got %f", status, val)
+			}
+		}
+
+		// Verify execution time
+		executionTime := testutil.ToFloat64(exporter.buildTotalExecutionTime.WithLabelValues(failureBuildID))
+		if executionTime != 60.0 {
+			t.Errorf("Expected execution time 60.0 seconds, got %f", executionTime)
+		}
+
+		t.Logf("✓ Failure build status and execution time validated")
+	})
 
 	// Additional test: Verify metrics cleanup after build removal
 	// This ensures the fix for the flaky_failures bug (metrics not being reset) works correctly


### PR DESCRIPTION
## Summary

This PR adds two important enhancements to the RSpecQ Exporter:

### Changes

1. **New Status Codes (success/failure)**
   - Added support for `success` and `failure` status codes in addition to existing `initializing` and `ready` statuses
   - Build status metric now properly tracks all four possible states
   - Comprehensive tests added to validate status transitions

2. **Total Execution Time Metric**
   - Added new `rspecq_build_total_execution_time_seconds` gauge metric
   - Tracks the sum of all worker execution times for each build (in seconds)
   - Converted from Redis milliseconds to seconds for better Prometheus compatibility
   - Includes full test coverage

### Commits

- `5937e68` - add total_execution_time_seconds gauge
- `7f89ac8` - add new status codes (sucess/failure)

### Testing

All tests pass, including new integration tests for:
- Success/failure status tracking
- Total execution time calculation