### PR TITLE
Add build_splitted_timings_seconds metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ By default, per-worker metrics are disabled to reduce metric cardinality. To ena
 | `rspecq_build_total_execution_time_seconds` | Gauge | `build_id` | Total execution time for the build in seconds (sum of all worker execution times) |
 | `rspecq_build_queue_info` | Gauge | `build_id`, `stat` | Queue initialization statistics dynamically collected from Redis. Common stat values: `jobs` (total jobs published), `files_splitted` (slow files split into examples), `splitted_jobs` (jobs from splitting), `untimed_jobs` (jobs without timing data), `untimed_splitted_jobs` (untimed jobs among split examples) |
 | `rspecq_build_queue_info_strings` | Gauge | `build_id`, `field`, `value` | Non-numeric queue info fields exposed as labels (value is always 1). Useful for tracking metadata like version, environment, or status strings |
+| `rspecq_build_splitted_timings_seconds` | Gauge | `build_id`, `spec` | Execution time in seconds for spec files that were split into multiple jobs (slowest files) |
 
 ### Worker Metrics
 
@@ -234,24 +235,28 @@ rspecq_build_total_execution_time_seconds
 ### Queue Statistics
 
 #### Job Splitting Efficiency
+
 ```promql
 # Percentage of jobs that came from file splitting
 100 * rspecq_build_queue_info{stat="splitted_jobs"} / rspecq_build_queue_info{stat="jobs"}
 ```
 
 #### Test Coverage Gap (Untimed Tests)
+
 ```promql
 # Percentage of jobs without historical timing data
 100 * rspecq_build_queue_info{stat="untimed_jobs"} / rspecq_build_queue_info{stat="jobs"}
 ```
 
 #### Slow File Detection
+
 ```promql
 # Number of slow files being split across builds
 rspecq_build_queue_info{stat="files_splitted"}
 ```
 
 #### All Queue Initialization Stats
+
 ```promql
 # View all queue statistics for a build
 rspecq_build_queue_info{build_id="myapp-123"}
@@ -268,6 +273,13 @@ rspecq_build_queue_info_strings{field="environment",value="production"}
 
 # View all metadata fields for a build
 rspecq_build_queue_info_strings{build_id="myapp-123"}
+```
+
+### Slowest Split Spec Files
+
+```promql
+# Show the slowest spec files that were split into multiple jobs
+topk(10, rspecq_build_splitted_timings_seconds)
 ```
 
 ## Grafana Dashboard
@@ -311,6 +323,7 @@ RSpecQ stores data in Redis with the following key patterns:
 - `<build_id>:queue:ready_at` - STRING with Unix timestamp when queue became ready
 - `<build_id>:queue:finished_at` - STRING with Unix timestamp when build finished
 - `<build_id>:build_execution_time_ms` - STRING with total execution time in milliseconds (sum of all worker execution times)
+- `<build_id>:build_splitted_timings` - ZSET of slowest spec files that were split into multiple jobs (member = spec file path, score = execution time in seconds)
 
 **Queue Statistics:**
 - `<build_id>:info` - HASH containing queue initialization statistics (dynamically collected):

--- a/exporter.go
+++ b/exporter.go
@@ -70,6 +70,7 @@ type RSpecQExporter struct {
 	buildNextTestTiming     *prometheus.GaugeVec
 	buildQueueInfo          *prometheus.GaugeVec
 	buildQueueInfoStrings   *prometheus.GaugeVec
+	buildSplittedTimings    *prometheus.GaugeVec
 
 	// Worker-level metrics
 	workerHeartbeats *prometheus.GaugeVec
@@ -303,6 +304,14 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		},
 		append(append(exporter.labelNames, "field"), "value"),
 	)
+	exporter.buildSplittedTimings = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "build_splitted_timings_seconds",
+			Help:      "Execution time in seconds for splitted spec files (slowest files that were split into multiple jobs)",
+		},
+		append(exporter.labelNames, "spec"),
+	)
 	exporter.globalTimings = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -390,6 +399,7 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		exporter.buildNextTestTiming,
 		exporter.buildQueueInfo,
 		exporter.buildQueueInfoStrings,
+		exporter.buildSplittedTimings,
 	}
 
 	// Per-worker metrics (conditionally included)
@@ -433,6 +443,7 @@ func NewRSpecQExporter(rdb *redis.Client, disablePerWorkerMetrics bool, buildIDR
 		exporter.buildNextTestTiming,
 		exporter.buildQueueInfo,
 		exporter.buildQueueInfoStrings,
+		exporter.buildSplittedTimings,
 	}
 
 	// Add per-worker metrics to resetable list if enabled
@@ -653,6 +664,7 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	electedMasterKey := buildID + ":queue:elected_master_at"
 	readyKey := buildID + ":queue:ready_at"
 	executionTimeKey := buildID + ":build_execution_time_ms"
+	splittedTimingsKey := buildID + ":build_splitted_timings"
 
 	// Execute all commands atomically using pipeline with MULTI/EXEC
 	pipe := b.rdb.TxPipeline()
@@ -685,6 +697,7 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 	readyAtCmd := pipe.Get(ctx, readyKey)
 	finishedAtCmd := pipe.Get(ctx, finishedKey)
 	executionTimeCmd := pipe.Get(ctx, executionTimeKey)
+	splittedTimingsCmd := pipe.ZRevRangeWithScores(ctx, splittedTimingsKey, 0, -1)
 
 	// Execute the transaction
 	_, err := pipe.Exec(ctx)
@@ -842,6 +855,21 @@ func (b *Build) CollectMetrics(ctx context.Context, e *RSpecQExporter) (bool, er
 				labelsWithFieldValue["value"] = statValue
 				e.buildQueueInfoStrings.With(labelsWithFieldValue).Set(1)
 			}
+		}
+	}
+
+	// Process results - Splitted timings (slowest splitted spec files)
+	if splittedTimings, err := splittedTimingsCmd.Result(); err == nil {
+		// Create labels with spec dimension
+		splittedLabels := make(prometheus.Labels)
+		for k, v := range labels {
+			splittedLabels[k] = v
+		}
+
+		for _, timing := range splittedTimings {
+			specFile := timing.Member.(string)
+			splittedLabels["spec"] = specFile
+			e.buildSplittedTimings.With(splittedLabels).Set(timing.Score)
 		}
 	}
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -421,6 +421,12 @@ func TestE2E_HappyPath_AllMetrics(t *testing.T) {
 	// the list order is [job3, job2, job1], and LINDEX 0 returns "job3"
 	rdb.ZAdd(ctx, "timings", &redis.Z{Score: 3.7, Member: "job3"})
 
+	// Splitted timings - slowest spec files that were split into multiple jobs
+	rdb.ZAdd(ctx, buildID+":build_splitted_timings",
+		&redis.Z{Score: 42.5, Member: "spec/slow_feature_spec.rb"},
+		&redis.Z{Score: 35.8, Member: "spec/models/user_spec.rb"},
+	)
+
 	// Create exporter and register with a custom registry for testing
 	exporter, err := NewRSpecQExporter(rdb, false, "")
 	if err != nil {
@@ -553,6 +559,14 @@ func TestE2E_HappyPath_AllMetrics(t *testing.T) {
 		// Queue info strings metric (non-numeric values)
 		{`rspecq_build_queue_info_strings{build_id="e2e-test-build",field="version",value="1.2.3"}`, 1, func() float64 {
 			return testutil.ToFloat64(exporter.buildQueueInfoStrings.WithLabelValues(buildID, "version", "1.2.3"))
+		}},
+
+		// Splitted timings metrics (slowest spec files that were split)
+		{`rspecq_build_splitted_timings_seconds{build_id="e2e-test-build",spec="spec/slow_feature_spec.rb"}`, 42.5, func() float64 {
+			return testutil.ToFloat64(exporter.buildSplittedTimings.WithLabelValues(buildID, "spec/slow_feature_spec.rb"))
+		}},
+		{`rspecq_build_splitted_timings_seconds{build_id="e2e-test-build",spec="spec/models/user_spec.rb"}`, 35.8, func() float64 {
+			return testutil.ToFloat64(exporter.buildSplittedTimings.WithLabelValues(buildID, "spec/models/user_spec.rb"))
 		}},
 
 		// Global metrics (now includes the job3 timing, so count is 4 instead of 3)


### PR DESCRIPTION
Expose RSpecQ's build_splitted_timings data as a Prometheus metric to track
the slowest spec files that were split into multiple jobs for parallel
execution.

New metric:
  rspecq_build_splitted_timings_seconds{build_id="myapp-123",spec="./spec/slow_spec.rb"} 45.7

Changes:
- Add buildSplittedTimings GaugeVec metric with build_id and spec labels
- Collect data from <build_id>:build_splitted_timings Redis ZSET
- Add comprehensive test coverage in E2E test (TestE2E_HappyPath_AllMetrics)
- Update README with metric documentation, example query, and Redis key info

This allows monitoring which spec files are being split and their execution
times, useful for debugging slow tests and optimizing test suite performance.
